### PR TITLE
fix: ci revamp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,61 @@
+# =============================================================================
+# Environment Variables
+# Copy this file to .env and fill in the values for your environment.
+# Never commit the .env file to version control.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Application
+# -----------------------------------------------------------------------------
+# The port the backend HTTP server listens on
+PORT=
+
+# -----------------------------------------------------------------------------
+# Database (PostgreSQL)
+# -----------------------------------------------------------------------------
+# PostgreSQL username
+DB_USER=
+
+# PostgreSQL password
+DB_PASSWORD=
+
+# Hostname or IP address of the PostgreSQL server
+DB_HOST=
+
+# Port the PostgreSQL server listens on (default: 5432)
+DB_PORT=
+
+# Name of the PostgreSQL database
+DB_NAME=
+
+# -----------------------------------------------------------------------------
+# Supabase
+# -----------------------------------------------------------------------------
+# The public URL of your Supabase project (e.g. https://<project>.supabase.co)
+SUPABASE_URL=
+
+# Supabase anonymous (public) API key — safe to expose in the browser
+SUPABASE_ANON_KEY=
+
+# Supabase service role key — keep this secret, never expose to clients
+SUPABASE_SERVICE_ROLE_KEY=
+
+# -----------------------------------------------------------------------------
+# Google OAuth
+# -----------------------------------------------------------------------------
+# OAuth 2.0 Client ID from the Google Cloud Console
+GOOGLE_CLIENT_ID=
+
+# OAuth 2.0 Client Secret from the Google Cloud Console
+GOOGLE_CLIENT_SECRET=
+
+# Authorised redirect URI registered in the Google Cloud Console
+# Must match exactly (e.g. http://localhost:8080/auth/google/callback)
+GOOGLE_REDIRECT_URI=
+
+# -----------------------------------------------------------------------------
+# JWT
+# -----------------------------------------------------------------------------
+# Secret key used to sign and verify JSON Web Tokens
+# Use a long, random string (e.g. openssl rand -hex 64)
+JWT_SECRET=

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS
+# Defines who is responsible for reviewing changes to files in this repository.
+# The last matching pattern takes precedence.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo
+* @forge-s26-team

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior in the application
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+
+A clear and concise description of what actually happened.
+
+## Screenshots / Logs
+
+If applicable, add screenshots or log output to help explain your problem.
+
+## Environment
+
+- OS: [e.g. macOS 14, Ubuntu 22.04]
+- Node version: [e.g. 20.x]
+- Browser (if frontend): [e.g. Chrome 120]
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for the project
+title: '[FEAT] '
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+A clear and concise description of the feature you are requesting.
+
+## Motivation
+
+Why is this feature needed? What problem does it solve? Who benefits from it?
+
+## Proposed Solution
+
+Describe the solution you would like to see. Be as specific as possible.
+
+## Alternatives Considered
+
+Describe any alternative solutions or features you have considered and why you ruled them out.
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Additional Context
+
+Add any other context, mockups, or screenshots about the feature request here.

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,54 @@
+---
+# Dependency audit workflow
+# Runs npm audit on backend and frontend to catch high-severity vulnerabilities on every PR
+name: Dependency Audit
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  audit-backend:
+    name: Audit Backend Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Run npm audit (backend)
+        working-directory: backend
+        run: npm audit --audit-level=high
+
+  audit-frontend:
+    name: Audit Frontend Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run npm audit (frontend)
+        working-directory: frontend
+        run: npm audit --audit-level=high

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: frontend
-        run: npm ci
+        run: npm install --legacy-peer-deps
 
       - name: Run npm audit (frontend)
         working-directory: frontend

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 ---
 # Continuous Integration workflow
-# Runs linting and tests on every push to main and on pull requests
+# Runs linting, typechecking, tests, and builds on every push to main and on pull requests
 name: CI
 
 on:
@@ -14,9 +14,10 @@ on:
   pull_request:
     branches:
       - main
+
 jobs:
   # Linting job using MegaLinter
-  megalinter:
+  lint:
     name: MegaLinter
     runs-on: ubuntu-latest
     steps:
@@ -27,17 +28,48 @@ jobs:
       - name: MegaLinter
         uses: oxsecurity/megalinter@v7
         env:
-          # Only enable JavaScript and TypeScript linters
-          ENABLE_LINTERS: JAVASCRIPT, TYPESCRIPT
+          # Enable all linters for JavaScript and TypeScript
+          ENABLE: JAVASCRIPT,TYPESCRIPT
           # Post results as GitHub PR comments
-          REPORTERS: github_comment
           GITHUB_COMMENT_REPORTER: true
-
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Validate all files in the codebase
           VALIDATE_ALL_CODEBASE: true
           LOG_LEVEL: INFO
-  # Testing job
-  test:
+
+  # Typecheck job — runs tsc --noEmit in backend/
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Cache backend node_modules
+        uses: actions/cache@v4
+        with:
+          path: backend/node_modules
+          key: ${{ runner.os }}-backend-node-modules-${{ hashFiles('backend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-backend-node-modules-
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Run TypeScript typecheck
+        working-directory: backend
+        run: npx tsc --noEmit
+
+  # Unit testing job
+  unit-test:
     name: Run Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -48,11 +80,21 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Cache backend node_modules
+        uses: actions/cache@v4
+        with:
+          path: backend/node_modules
+          key: ${{ runner.os }}-backend-node-modules-${{ hashFiles('backend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-backend-node-modules-
 
       - name: Install dependencies
         working-directory: backend
-        run: npm install
+        run: npm ci
 
       - name: Run tests
         run: npm test -- --coverage
@@ -66,13 +108,40 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  # Build job — depends on lint, typecheck, and unit-test all passing
   build:
     name: Build Images
     runs-on: ubuntu-latest
+    needs: [lint, typecheck, unit-test]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
-      - name: Build Frontend Image
-        run: docker compose build frontend
+
+      - name: Cache frontend node_modules
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-node-modules-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Backend Image
-        run: docker compose build backend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./images/backend/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build Frontend Image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./images/frontend/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,31 @@
+---
+# Commitlint workflow
+# Enforces Conventional Commits format on all PR commits
+name: Commitlint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  commitlint:
+    name: Lint Commit Messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          # Fetch full history so commitlint can compare against origin/main
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli @commitlint/config-conventional
+
+      - name: Run commitlint
+        run: npx commitlint --from origin/main --to HEAD --verbose

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,129 @@
+---
+# Deploy workflow — deploys to staging automatically after CI passes;
+# production requires manual approval via GitHub environment protection rules.
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
+
+jobs:
+  staging:
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+    # Uses the "staging" GitHub environment for variable/secret scoping
+    environment: staging
+    # On push to main, always deploy staging.
+    # On manual dispatch, only run this job when staging is selected.
+    if: github.event_name == 'push' || github.event.inputs.environment == 'staging'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ---------------------------------------------------------------
+      # Replace the echo commands below with your real deploy commands.
+      # Examples: kubectl apply, helm upgrade, fly deploy, etc.
+      # ---------------------------------------------------------------
+      - name: Deploy backend to staging
+        run: |
+          # replace with your deploy command
+          echo "Deploying backend to staging..."
+          echo "IMAGE=ghcr.io/${{ github.repository_owner }}/northstar-backend:latest"
+
+      - name: Deploy frontend to staging
+        run: |
+          # replace with your deploy command
+          echo "Deploying frontend to staging..."
+          echo "IMAGE=ghcr.io/${{ github.repository_owner }}/northstar-frontend:latest"
+
+      # Basic smoke test — verifies the health endpoint returns HTTP 200
+      - name: Smoke test — health check
+        run: |
+          echo "Running smoke test against staging health endpoint..."
+          # replace the URL below with your real staging base URL, e.g.:
+          # BASE_URL="${{ vars.STAGING_URL }}"
+          BASE_URL="http://localhost:8080"
+          for i in $(seq 1 5); do
+            STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" "${BASE_URL}/api/v1/health" || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "Health check passed (HTTP $STATUS)"
+              exit 0
+            fi
+            echo "Attempt $i: got HTTP $STATUS, retrying in 5s..."
+            sleep 5
+          done
+          echo "Smoke test failed after 5 attempts"
+          exit 1
+
+  production:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    # The "production" GitHub environment must have a required reviewer configured
+    # in Settings → Environments → production → Required reviewers.
+    # GitHub will pause this job until a reviewer approves the deployment.
+    environment: production
+    # On push to main, also queue a production deployment (approval gates it).
+    # On manual dispatch, only run when production is selected.
+    if: github.event_name == 'push' || github.event.inputs.environment == 'production'
+    needs: staging
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ---------------------------------------------------------------
+      # Replace the echo commands below with your real deploy commands.
+      # ---------------------------------------------------------------
+      - name: Deploy backend to production
+        run: |
+          # replace with your deploy command
+          echo "Deploying backend to production..."
+          echo "IMAGE=ghcr.io/${{ github.repository_owner }}/northstar-backend:${{ github.sha }}"
+
+      - name: Deploy frontend to production
+        run: |
+          # replace with your deploy command
+          echo "Deploying frontend to production..."
+          echo "IMAGE=ghcr.io/${{ github.repository_owner }}/northstar-frontend:${{ github.sha }}"
+
+      - name: Smoke test — health check
+        run: |
+          echo "Running smoke test against production health endpoint..."
+          # replace the URL below with your real production base URL, e.g.:
+          # BASE_URL="${{ vars.PRODUCTION_URL }}"
+          BASE_URL="http://localhost:8080"
+          for i in $(seq 1 5); do
+            STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" "${BASE_URL}/api/v1/health" || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "Health check passed (HTTP $STATUS)"
+              exit 0
+            fi
+            echo "Attempt $i: got HTTP $STATUS, retrying in 5s..."
+            sleep 5
+          done
+          echo "Smoke test failed after 5 attempts"
+          exit 1

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,78 @@
+---
+# Docs workflow — generates TypeDoc API documentation from the backend source
+# and deploys it to GitHub Pages.
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+  # Allow manual triggering from the GitHub UI
+  workflow_dispatch: {}
+
+# Grant the minimum permissions required to deploy to Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only allow one concurrent deployment; cancel in-progress runs
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-docs:
+    name: Build TypeDoc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Cache backend node_modules
+        uses: actions/cache@v4
+        with:
+          path: backend/node_modules
+          key: ${{ runner.os }}-backend-node-modules-${{ hashFiles('backend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-backend-node-modules-
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Install TypeDoc
+        working-directory: backend
+        run: npm install --save-dev typedoc
+
+      - name: Generate TypeDoc documentation
+        working-directory: backend
+        run: npx typedoc --entryPointStrategy expand src/ --out docs/
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      # Upload the generated docs/ directory as the Pages artifact
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: backend/docs/
+
+  deploy-docs:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build-docs
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,93 @@
+---
+# End-to-end test workflow — spins up the full stack with Docker Compose
+# and runs Playwright tests on every pull request targeting main.
+name: E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Cache frontend node_modules
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-node-modules-
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Start the full application stack in the background
+      - name: Start application with Docker Compose
+        run: |
+          docker compose up -d backend frontend
+          echo "Waiting for services to be healthy..."
+          # Wait for backend health endpoint
+          for i in $(seq 1 20); do
+            STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" http://localhost:8080/api/v1/health || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "Backend ready (HTTP $STATUS)"
+              break
+            fi
+            echo "Attempt $i: backend HTTP $STATUS — retrying in 5s..."
+            sleep 5
+          done
+          # Wait for frontend to respond
+          for i in $(seq 1 20); do
+            STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" http://localhost:3000 || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "Frontend ready (HTTP $STATUS)"
+              break
+            fi
+            echo "Attempt $i: frontend HTTP $STATUS — retrying in 5s..."
+            sleep 5
+          done
+
+      - name: Run Playwright tests
+        working-directory: frontend
+        run: npx playwright test
+        env:
+          # Base URLs used inside Playwright tests (override via playwright.config.ts)
+          BASE_URL: 'http://localhost:3000'
+          API_URL: 'http://localhost:8080'
+
+      - name: Stop Docker Compose services
+        if: always()
+        run: docker compose down
+
+      # Upload screenshots and traces whenever tests fail so failures can be debugged
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            frontend/test-results/
+            frontend/playwright-report/
+          retention-days: 7

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: frontend
-        run: npm ci
+        run: npm install --legacy-peer-deps
 
       - name: Install Playwright browsers
         working-directory: frontend

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -37,8 +37,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
           cache-dependency-path: backend/package-lock.json
 
       - name: Cache backend node_modules
@@ -55,7 +55,8 @@ jobs:
 
       - name: Run schema integration tests
         working-directory: backend
-        run: npm test -- --testPathPattern=schema/tests
+        run: npm test -- --testPathPatterns=schema/tests
+
         env:
           # Database connection variables consumed by the test suite
           POSTGRES_HOST: localhost

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,67 @@
+---
+# Integration test workflow — runs database-backed schema tests against a
+# real PostgreSQL 15 service container on every pull request targeting main.
+name: Integration Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  integration:
+    name: Schema Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpassword
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        # Wait until PostgreSQL is accepting connections before starting tests
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Cache backend node_modules
+        uses: actions/cache@v4
+        with:
+          path: backend/node_modules
+          key: ${{ runner.os }}-backend-node-modules-${{ hashFiles('backend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-backend-node-modules-
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Run schema integration tests
+        working-directory: backend
+        run: npm test -- --testPathPattern=schema/tests
+        env:
+          # Database connection variables consumed by the test suite
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpassword
+          POSTGRES_DB: testdb
+          DATABASE_URL: postgresql://testuser:testpassword@localhost:5432/testdb
+          NODE_ENV: test

--- a/.github/workflows/lighthouse.yaml
+++ b/.github/workflows/lighthouse.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: frontend
-        run: npm ci
+        run: npm install --legacy-peer-deps
 
       - name: Build frontend (Next.js)
         working-directory: frontend

--- a/.github/workflows/lighthouse.yaml
+++ b/.github/workflows/lighthouse.yaml
@@ -1,0 +1,53 @@
+---
+# Lighthouse CI workflow — audits frontend performance, accessibility,
+# and best-practices on every pull request targeting main.
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lighthouse:
+    name: Lighthouse Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Cache frontend node_modules
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-node-modules-
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend (Next.js)
+        working-directory: frontend
+        run: npm run build
+        env:
+          # Suppress Next.js telemetry in CI
+          NEXT_TELEMETRY_DISABLED: '1'
+
+      - name: Install Lighthouse CI
+        run: npm install -g @lhci/cli@0.14.x
+
+      # Run LHCI using the budget defined in .lighthouserc.json at the repo root.
+      # The `autorun` command collects, asserts, and uploads results.
+      - name: Run Lighthouse CI
+        run: lhci autorun
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -1,0 +1,113 @@
+---
+# OpenAPI spec workflow — generates openapi.json from openapi.yaml and deploys
+# it to GitHub Pages alongside the TypeDoc documentation.
+name: OpenAPI Spec Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+# Minimum permissions required for a Pages deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One concurrent Pages deployment at a time; cancel in-progress runs
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  generate-and-deploy:
+    name: Generate OpenAPI JSON and Deploy to Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Cache backend node_modules
+        uses: actions/cache@v4
+        with:
+          path: backend/node_modules
+          key: ${{ runner.os }}-backend-node-modules-${{ hashFiles('backend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-backend-node-modules-
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      # Generate backend/api/openapi.json from backend/api/openapi.yaml
+      - name: Generate OpenAPI JSON
+        working-directory: backend
+        run: npx ts-node scripts/generate-openapi.ts
+
+      # Also generate TypeDoc documentation so both are co-deployed
+      - name: Install TypeDoc
+        working-directory: backend
+        run: npm install --save-dev typedoc
+
+      - name: Generate TypeDoc documentation
+        working-directory: backend
+        run: npx typedoc --entryPointStrategy expand src/ --out docs/
+
+      # Assemble the Pages site:
+      #   /          → TypeDoc HTML documentation
+      #   /openapi/  → openapi.json spec (and a simple viewer)
+      - name: Assemble Pages site
+        run: |
+          mkdir -p _site/openapi
+          # Copy TypeDoc output to site root
+          cp -r backend/docs/. _site/
+          # Copy generated OpenAPI JSON to /openapi/
+          cp backend/api/openapi.json _site/openapi/openapi.json
+          # Create a minimal index page for the openapi directory
+          cat > _site/openapi/index.html <<'HTML'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="UTF-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            <title>NorthStar API Spec</title>
+            <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+          </head>
+          <body>
+            <div id="swagger-ui"></div>
+            <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+            <script>
+              SwaggerUIBundle({
+                url: './openapi.json',
+                dom_id: '#swagger-ui',
+                presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
+                layout: 'StandaloneLayout'
+              });
+            </script>
+          </body>
+          </html>
+          HTML
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,106 @@
+---
+# Release workflow — versions packages with Changesets and builds/pushes Docker images to ghcr.io
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Changesets Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: write
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          # Full history needed for Changesets to compute version bumps
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci
+
+      # Creates a "Version Packages" PR or publishes if the PR was merged
+      - name: Create Release Pull Request or Publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # Command run when Changesets decides to publish a new version
+          publish: npx changeset tag
+          title: 'chore: version packages'
+          commit: 'chore: version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Builds and pushes Docker images to ghcr.io only when a real release is published
+  docker:
+    name: Push Docker Images
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      # Extract the version from the first published package
+      - name: Extract released version
+        id: version
+        run: |
+          echo "version=$(echo '${{ needs.release.outputs.publishedPackages }}' | jq -r '.[0].version')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Derive the lowercase repository owner for ghcr.io image names
+      - name: Compute image prefix
+        id: meta
+        run: echo "prefix=ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/$(echo '${{ github.event.repository.name }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./images/backend/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.prefix }}-backend:${{ steps.version.outputs.version }}
+            ${{ steps.meta.outputs.prefix }}-backend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./images/frontend/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.prefix }}-frontend:${{ steps.version.outputs.version }}
+            ${{ steps.meta.outputs.prefix }}-frontend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run TruffleHog
-        uses: trufflesecurity/trufflehog@v3
+        uses: trufflesecurity/trufflehog@v3.93.8
         with:
           # Scan commits introduced by this PR only
           base: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -1,0 +1,28 @@
+---
+# Secret scanning workflow
+# Uses TruffleHog to detect secrets and credentials accidentally committed to the repo
+name: Secret Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  trufflehog:
+    name: TruffleHog Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          # Fetch full history for thorough scanning
+          fetch-depth: 0
+
+      - name: Run TruffleHog
+        uses: trufflesecurity/trufflehog@v3
+        with:
+          # Scan commits introduced by this PR only
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
+          extra_args: --only-verified

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: frontend
-        run: npm ci
+        run: npm install --legacy-peer-deps
 
       - name: Run Snyk to check for vulnerabilities (frontend)
         uses: snyk/actions/node@master

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,133 @@
+---
+# Security scanning workflow — runs OWASP ZAP (DAST) and Snyk (SCA/SAST) scans.
+# Scheduled weekly and triggered on every push to main.
+name: Security Scans
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Every Sunday at midnight UTC
+    - cron: '0 0 * * 0'
+  workflow_dispatch: {}
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # OWASP ZAP — Dynamic Application Security Testing (DAST)
+  # Spins up the backend via Docker Compose and runs a full ZAP scan against it.
+  # ---------------------------------------------------------------------------
+  zap-scan:
+    name: OWASP ZAP Full Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Start only the backend service (and its deps) so ZAP has a target
+      - name: Start backend with Docker Compose
+        run: |
+          docker compose up -d backend
+          # Wait for the health endpoint to become available before scanning
+          echo "Waiting for backend to be ready..."
+          for i in $(seq 1 20); do
+            STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" http://localhost:8080/api/v1/health || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "Backend is ready (HTTP $STATUS)"
+              break
+            fi
+            echo "Attempt $i: HTTP $STATUS — retrying in 5s..."
+            sleep 5
+          done
+
+      - name: OWASP ZAP Full Scan
+        uses: zaproxy/action-full-scan@v0.10.0
+        with:
+          target: 'http://localhost:8080'
+          # Fail the workflow if ZAP finds issues at WARN level or above
+          fail_action: false
+          # Upload the HTML report as an artifact
+          artifact_name: zap-report
+          # Allow the ZAP container to reach the host network
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
+          cmd_options: '-I'
+
+      - name: Stop Docker Compose services
+        if: always()
+        run: docker compose down
+
+  # ---------------------------------------------------------------------------
+  # Snyk — Software Composition Analysis for backend and frontend
+  # ---------------------------------------------------------------------------
+  snyk-backend:
+    name: Snyk Scan — Backend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Run Snyk to check for vulnerabilities (backend)
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high
+          command: test
+        # Use the backend directory as the working directory for Snyk
+        # The snyk/actions/node action runs in the repo root by default;
+        # override with the `args` path flag.
+
+      # Surface Snyk results in the GitHub Security tab via SARIF upload
+      - name: Upload Snyk SARIF report (backend)
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        continue-on-error: true
+        with:
+          sarif_file: snyk.sarif
+
+  snyk-frontend:
+    name: Snyk Scan — Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run Snyk to check for vulnerabilities (frontend)
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high --file=frontend/package.json
+          command: test
+
+      - name: Upload Snyk SARIF report (frontend)
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        continue-on-error: true
+        with:
+          sarif_file: snyk.sarif

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,47 @@
+---
+# Stale issue/PR management workflow
+# Marks issues and PRs stale after 30 days of inactivity, closes them after 7 more days
+name: Stale
+
+on:
+  schedule:
+    # Run daily at midnight UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  stale:
+    name: Mark and Close Stale Issues and PRs
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Stale Action
+        uses: actions/stale@v9
+        with:
+          # Number of days of inactivity before an issue/PR is marked stale
+          days-before-stale: 30
+          # Number of days of inactivity after being marked stale before closing
+          days-before-close: 7
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            any activity in the last 30 days. It will be closed in 7 days if no further
+            activity occurs. If this issue is still relevant, please leave a comment or
+            remove the stale label.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            any activity in the last 30 days. It will be closed in 7 days if no further
+            activity occurs. If this PR is still relevant, please leave a comment, push
+            new commits, or remove the stale label.
+          close-issue-message: >
+            This issue was closed automatically after being stale for 7 days with no activity.
+            Feel free to reopen it if the issue is still relevant.
+          close-pr-message: >
+            This pull request was closed automatically after being stale for 7 days with no
+            activity. Feel free to reopen it if the work is still relevant.
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          # Labels that prevent an issue/PR from being marked stale
+          exempt-issue-labels: 'pinned,security,bug'
+          exempt-pr-labels: 'pinned,security'

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,19 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./frontend/.next",
+      "numberOfRuns": 3
+    },
+    "assert": {
+      "preset": "lighthouse:no-pwa",
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.7 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:best-practices": ["error", { "minScore": 0.8 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,186 @@
-# Contributing
+# Contributing to forge-s26-project
 
-## Overview
+Thank you for contributing! This document explains the conventions and processes to follow.
 
-To submit any new changes to the code, create a pull request using the provided template. Make sure
-provide a descriptive title to the template and if applicable, link the associated issue with it. 
+---
 
-## Backend PRs
+## Conventional Commits
 
-If you're writing backend code, please include a screenshot of your endpoint(s) working through
-manual testing (Postman, etc.). 
-Please also include URL + parameters you passed in for the calls so that's visible and easy for someone
-to replicate those tests, if and when needed! 
+All commit messages **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. This is enforced automatically by `commitlint` on every PR.
 
-## Frontend PRs
+### Format
 
-If you're writing frontend code, please include a screenshot or screen recording of your updates! 
+```
+<type>(<optional scope>): <short description>
 
-## Review process
+[optional body]
 
-Once a pull request has been submitted, make sure to mark your project lead as one
-of the reviewers of the PR and if there's other team members that have worked on sections of the 
-code you've edited in places, feel free to also request a code review from them as well. 
+[optional footer(s)]
+```
 
-**Tip:** You can open a *draft PR* to run CI checks before officially submitting your PR for review. 
-This also provides space for your team to have very real updates of your work throughout the week. 
+### Allowed Types
 
-If your pull request is reviewed and not approved, the reviewer will leave some suggestions for changes. (Sometimes we will approve and still leave suggestions). 
-Once changes are made, please ask for a re-review and if more conversation is needed on the comments, 
-feel free to also reach out to your PL through Slack! 
+| Type       | When to use                                            |
+|------------|--------------------------------------------------------|
+| `feat`     | A new feature                                         |
+| `fix`      | A bug fix                                             |
+| `docs`     | Documentation changes only                           |
+| `style`    | Formatting changes (no logic change)                 |
+| `refactor` | Code refactoring (no new feature or bug fix)         |
+| `test`     | Adding or updating tests                              |
+| `chore`    | Maintenance tasks (dependency updates, tooling, etc.) |
+| `ci`       | CI/CD configuration changes                          |
+| `perf`     | Performance improvements                             |
+| `build`    | Changes affecting the build system                   |
+| `revert`   | Reverting a previous commit                          |
+
+### Examples
+
+```
+feat(auth): add Google OAuth login flow
+fix(reviews): handle null professor ID gracefully
+docs: update API specification for reviews endpoint
+chore(deps): bump express from 4.18 to 5.2
+```
+
+---
+
+## Pull Request Process
+
+1. **Branch naming** — use a descriptive prefix: `feat/`, `fix/`, `chore/`, `docs/`, etc.
+   - Example: `feat/prof-review-endpoint`
+
+2. **Open a PR against `main`** and fill in the PR template completely.
+
+3. **All CI checks must pass** before merging:
+   - MegaLinter (lint)
+   - TypeScript typecheck
+   - Unit tests
+   - Docker image builds
+   - Commitlint
+   - Secret scan
+   - Dependency audit
+   - Changeset check (unless the PR title starts with `chore:` or `docs:`)
+
+4. **Request a review** from at least one teammate who is familiar with the area you changed.
+
+5. **Squash and merge** is the preferred merge strategy to keep the commit history clean.
+
+### Backend PRs
+
+If you are writing backend code, please include a screenshot of your endpoint(s) working through
+manual testing (Postman, etc.). Include the URL and parameters used so they are easy to replicate.
+
+### Frontend PRs
+
+If you are writing frontend code, please include a screenshot or screen recording of your updates.
+
+---
+
+## Running Tests Locally
+
+### Backend
+
+```bash
+cd backend
+
+# Install dependencies
+npm ci
+
+# Run all tests
+npm test
+
+# Run tests with coverage report
+npm run test:coverage
+
+# Run tests in watch mode (useful during development)
+npm run test:watch
+```
+
+Tests require a running PostgreSQL instance. The test suite uses Testcontainers to spin one up
+automatically — make sure Docker is running locally before running tests.
+
+### Frontend
+
+```bash
+cd frontend
+
+# Install dependencies
+npm ci
+
+# Build (catches type errors)
+npm run build
+
+# Lint
+npm run lint
+```
+
+---
+
+## Environment Setup
+
+1. Copy the example env file and fill in real values:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. See `.env.example` for descriptions of each variable.
+
+3. Validate your configuration:
+
+   ```bash
+   cd backend
+   npx ts-node scripts/validate-env.ts
+   ```
+
+---
+
+## Changeset Workflow
+
+This project uses [Changesets](https://github.com/changesets/changesets) to track notable changes
+across releases.
+
+### When is a changeset required?
+
+A changeset is required for any PR that introduces a user-visible change — new features, bug fixes,
+behaviour changes, or deprecations. It is **not** required for `chore:` or `docs:` PRs.
+
+### Creating a changeset
+
+```bash
+# From the repo root
+npx changeset
+```
+
+Follow the interactive prompts to:
+1. Select the packages affected (backend and/or frontend).
+2. Choose the bump type: `major`, `minor`, or `patch`.
+3. Write a short summary of the change.
+
+This creates a new file in `.changeset/`. Commit it alongside your code changes.
+
+### Releasing
+
+Maintainers run `npx changeset version` to apply all pending changesets and bump versions, then
+merge the resulting release PR.
+
+---
+
+## Review Process
+
+Once a pull request has been submitted, mark your project lead as a reviewer. If other team members
+have worked on sections of the code you edited, request their review as well.
+
+**Tip:** You can open a *draft PR* to run CI checks before officially submitting for review.
+
+If your pull request is not approved, the reviewer will leave suggestions for changes. Once changes
+are made, ask for a re-review. If more discussion is needed, reach out through Slack.
+
+---
+
+## Code Style
+
+- **Backend** — TypeScript strict mode. Run `npm run lint` and `npm run lint:fix` inside `backend/`.
+- **Frontend** — Next.js / ESLint. Run `npm run lint` inside `frontend/`.
+- Format code consistently; MegaLinter will catch common style violations in CI.

--- a/backend/scripts/generate-openapi.ts
+++ b/backend/scripts/generate-openapi.ts
@@ -1,0 +1,46 @@
+/**
+ * generate-openapi.ts
+ *
+ * Reads backend/api/openapi.yaml and writes it out as formatted JSON to
+ * backend/api/openapi.json.
+ *
+ * Usage (from the backend/ directory):
+ *   npx ts-node scripts/generate-openapi.ts
+ *
+ * Or with ts-node installed globally:
+ *   ts-node scripts/generate-openapi.ts
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'yamljs';
+
+// Resolve paths relative to the backend/ directory so the script works
+// regardless of the cwd it is invoked from.
+const backendDir = path.resolve(__dirname, '..');
+const inputPath = path.join(backendDir, 'api', 'openapi.yaml');
+const outputPath = path.join(backendDir, 'api', 'openapi.json');
+
+function main(): void {
+  if (!fs.existsSync(inputPath)) {
+    console.error(`[generate-openapi] Input file not found: ${inputPath}`);
+    process.exit(1);
+  }
+
+  console.log(`[generate-openapi] Reading  ${inputPath}`);
+  // yamljs.load parses YAML into a plain JavaScript object
+  const spec: unknown = yaml.load(inputPath);
+
+  const json = JSON.stringify(spec, null, 2);
+
+  // Ensure the output directory exists (it always should, but be safe)
+  const outputDir = path.dirname(outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  fs.writeFileSync(outputPath, json, 'utf-8');
+  console.log(`[generate-openapi] Written  ${outputPath}`);
+}
+
+main();

--- a/backend/scripts/validate-env.ts
+++ b/backend/scripts/validate-env.ts
@@ -1,0 +1,10 @@
+import { validateConfig } from '../src/config/config.js';
+
+try {
+    validateConfig();
+    console.log('Environment configuration is valid.');
+} catch (err) {
+    console.error('Invalid environment configuration:');
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -170,7 +170,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -245,7 +244,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -412,6 +410,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2047,7 +2046,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3041,7 +3039,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3132,7 +3129,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3273,7 +3269,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3673,7 +3668,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.2.tgz",
       "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3756,7 +3750,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.27.2.tgz",
       "integrity": "sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4088,7 +4081,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.2.tgz",
       "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4274,7 +4266,6 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4285,7 +4276,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4354,7 +4344,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4853,6 +4842,7 @@
       "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.17.4.tgz",
       "integrity": "sha512-XAvdG2dolBuV2Fx8bu1kjmQ2D4TonGzZH68Pgv/O9xMSFWdZtITSMFismeQLEAtMmGwze8qNJp3RgV+jStrJqg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^4.1.1",
@@ -4876,6 +4866,7 @@
       "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.1.1.tgz",
       "integrity": "sha512-5iLX6sR2ownbv4Mtejw6Ax+naosGvoT9kY+gcuHzANyUZZ+4NpeNdKMUhb6ag0acYej1Y7cmr/F2+4PrggMiVA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "global": "^4.4.0"
@@ -4890,6 +4881,7 @@
       "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.7.0.tgz",
       "integrity": "sha512-giab+EVRanChIupZK7gXjHy90y3nncA2phIOyG3Ne5fvpiMJzvqYwiTOnEVW2S4CoYcuKJkomat7bMXA/UoUZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "global": "~4.4.0",
@@ -4901,6 +4893,7 @@
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
       "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4922,7 +4915,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4957,6 +4949,7 @@
       "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.2.tgz",
       "integrity": "sha512-lc+/9s6iJvuaRe5qDlMTpCFjnwpkeOXp8qP3oiZ5jsj1MRg+SBVUmmICrhxHvc8OELSmc+fEyyxAuppY6hrWzw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^4.1.1",
@@ -5483,7 +5476,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5725,7 +5717,6 @@
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -5995,6 +5986,7 @@
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.0"
       },
@@ -6038,7 +6030,8 @@
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6413,7 +6406,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6599,7 +6591,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7318,6 +7309,7 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
       "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
@@ -7530,7 +7522,6 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -7913,7 +7904,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
       "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
@@ -8241,7 +8233,6 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -9000,6 +8991,7 @@
       "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.2.0.tgz",
       "integrity": "sha512-CRatFqpjVtMiMaKXxNvuI3I++vUumIXVVT/JpCpdU/FynV/ceVw1qpPyyBNindL+JlPMSesx+WX1QJaZEJSaMQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^4.1.1",
@@ -9121,6 +9113,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
       "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dom-walk": "^0.1.0"
       }
@@ -9153,6 +9146,7 @@
       "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.1.tgz",
       "integrity": "sha512-1FuyEWI5k2HcmhS1HkKnUAQV7yFPfXPht2DnRRGtoiiAAW+ESTbtEXIDpRkwdU+XyrQuwrIym7UkoPKsZ0SyFw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^4.0.0",
@@ -9183,6 +9177,7 @@
       "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.1.0.tgz",
       "integrity": "sha512-NTxawK/BBELJrYsZThEulyUMDVlLizKdxyAsMuzoCD1eFj97BVaA8D/CvKsKu6FOLYkFojN5CbM9h++ZTZtknA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "global": "^4.4.0"
@@ -10187,6 +10182,7 @@
       "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz",
       "integrity": "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.5.5"
       },
@@ -10274,6 +10270,7 @@
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -10402,7 +10399,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -10432,7 +10428,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -10481,7 +10476,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
       "integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -10545,7 +10539,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10555,7 +10548,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11857,6 +11849,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -11940,7 +11933,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12148,7 +12140,6 @@
       "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -12225,7 +12216,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12519,6 +12509,7 @@
       "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-4.1.0.tgz",
       "integrity": "sha512-TfrXJJg1Bv4t6TOCMEVMwF/CoS8iENYsWNKip8zfhB5kTcegiFYezEA0eHAJPU64ZC8NQbxQgOwAsYU8VXbOWA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "global": "^4.4.0"
       },
@@ -12534,13 +12525,15 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-4.2.0.tgz",
       "integrity": "sha512-YPq+wiKoGy2/M7ccjmlvwi58z2xsykkkfNMyIg4xb7EZQQNwB71hcSsB3o75CqQV7/y5lXkXhI/rsGAS7jfEmQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/videojs-vtt.js": {
       "version": "0.15.5",
       "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.5.tgz",
       "integrity": "sha512-yZbBxvA7QMYn15Lr/ZfhhLPrNpI/RmCSCqgIff57GC2gIrV5YfyzLfLyZMj0NnZSAz8syB4N0nHXpZg9MyrMOQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "global": "^4.3.1"
       }
@@ -12852,7 +12845,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Group all devDependencies together into a single PR",
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "devDependencies",
+      "automerge": false
+    },
+    {
+      "description": "Group all @types/* packages together into a single PR",
+      "matchPackagePrefixes": ["@types/"],
+      "groupName": "@types packages",
+      "automerge": false
+    },
+    {
+      "description": "Automerge patch updates for all packages",
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    }
+  ]
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# deploy.sh — Build Docker images and deploy to the target environment.
+#
+# Usage:
+#   ./scripts/deploy.sh staging
+#   ./scripts/deploy.sh production
+#
+# Make this file executable before use:
+#   chmod +x scripts/deploy.sh
+#
+# Required environment variables (set in CI or locally):
+#   GITHUB_TOKEN   — Personal access token with packages:write scope (for ghcr.io push)
+#   GITHUB_ACTOR   — GitHub username / organisation (used as the registry namespace)
+#   GITHUB_REPOSITORY_OWNER — lowercase org/user name on GitHub
+#
+# Optional:
+#   IMAGE_TAG — Docker image tag to use (defaults to the short git SHA)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log()  { echo "[deploy] $*"; }
+err()  { echo "[deploy] ERROR: $*" >&2; }
+die()  { err "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+ENVIRONMENT="${1:-}"
+
+if [[ -z "$ENVIRONMENT" ]]; then
+  die "No environment specified. Usage: $0 staging|production"
+fi
+
+if [[ "$ENVIRONMENT" != "staging" && "$ENVIRONMENT" != "production" ]]; then
+  die "Invalid environment '${ENVIRONMENT}'. Must be 'staging' or 'production'."
+fi
+
+log "Target environment: ${ENVIRONMENT}"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE_TAG="${IMAGE_TAG:-$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo "latest")}"
+REGISTRY="ghcr.io"
+OWNER="${GITHUB_REPOSITORY_OWNER:-$(git -C "$REPO_ROOT" remote get-url origin | sed 's|.*github.com[:/]\([^/]*\)/.*|\1|' | tr '[:upper:]' '[:lower:]')}"
+REPO_NAME="$(basename "$(git -C "$REPO_ROOT" remote get-url origin)" .git | tr '[:upper:]' '[:lower:]')"
+
+BACKEND_IMAGE="${REGISTRY}/${OWNER}/${REPO_NAME}-backend"
+FRONTEND_IMAGE="${REGISTRY}/${OWNER}/${REPO_NAME}-frontend"
+
+log "Registry   : ${REGISTRY}"
+log "Image tag  : ${IMAGE_TAG}"
+log "Backend    : ${BACKEND_IMAGE}:${IMAGE_TAG}"
+log "Frontend   : ${FRONTEND_IMAGE}:${IMAGE_TAG}"
+
+# ---------------------------------------------------------------------------
+# Step 1 — Build Docker images
+# ---------------------------------------------------------------------------
+
+log "Building Docker images..."
+
+docker build \
+  --file "${REPO_ROOT}/images/backend/Dockerfile" \
+  --tag "${BACKEND_IMAGE}:${IMAGE_TAG}" \
+  --tag "${BACKEND_IMAGE}:latest" \
+  "${REPO_ROOT}/backend"
+
+docker build \
+  --file "${REPO_ROOT}/images/frontend/Dockerfile" \
+  --tag "${FRONTEND_IMAGE}:${IMAGE_TAG}" \
+  --tag "${FRONTEND_IMAGE}:latest" \
+  "${REPO_ROOT}/frontend"
+
+log "Build complete."
+
+# ---------------------------------------------------------------------------
+# Step 2 — Log in to ghcr.io and push images
+# ---------------------------------------------------------------------------
+
+log "Logging in to ${REGISTRY}..."
+# replace with your login command if not using GITHUB_TOKEN
+echo "${GITHUB_TOKEN:-}" | docker login "${REGISTRY}" --username "${GITHUB_ACTOR:-${OWNER}}" --password-stdin
+
+log "Pushing images to ${REGISTRY}..."
+
+# replace with your push command
+docker push "${BACKEND_IMAGE}:${IMAGE_TAG}"
+docker push "${BACKEND_IMAGE}:latest"
+
+# replace with your push command
+docker push "${FRONTEND_IMAGE}:${IMAGE_TAG}"
+docker push "${FRONTEND_IMAGE}:latest"
+
+log "Images pushed successfully."
+
+# ---------------------------------------------------------------------------
+# Step 3 — Deploy to the target environment
+# ---------------------------------------------------------------------------
+
+log "Deploying to ${ENVIRONMENT}..."
+
+if [[ "$ENVIRONMENT" == "staging" ]]; then
+  # replace with your staging deploy command
+  # e.g.: kubectl set image deployment/backend backend="${BACKEND_IMAGE}:${IMAGE_TAG}" -n staging
+  # e.g.: fly deploy --image "${BACKEND_IMAGE}:${IMAGE_TAG}" --app northstar-backend-staging
+  echo "[deploy] replace with your staging deploy command"
+
+elif [[ "$ENVIRONMENT" == "production" ]]; then
+  # replace with your production deploy command
+  # e.g.: kubectl set image deployment/backend backend="${BACKEND_IMAGE}:${IMAGE_TAG}" -n production
+  # e.g.: fly deploy --image "${BACKEND_IMAGE}:${IMAGE_TAG}" --app northstar-backend-production
+  echo "[deploy] replace with your production deploy command"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4 — Health check
+# ---------------------------------------------------------------------------
+
+log "Running health check..."
+
+# replace BASE_URL with the real URL of your deployed service
+# e.g., BASE_URL="https://api-staging.northstar.example.com"
+BASE_URL="${HEALTH_CHECK_URL:-http://localhost:8080}"
+
+MAX_RETRIES=10
+RETRY_DELAY=10
+
+for i in $(seq 1 "${MAX_RETRIES}"); do
+  STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" \
+    "${BASE_URL}/api/v1/health" || true)
+
+  if [[ "$STATUS" == "200" ]]; then
+    log "Health check passed (HTTP ${STATUS}) after ${i} attempt(s)."
+    break
+  fi
+
+  if [[ "$i" -eq "${MAX_RETRIES}" ]]; then
+    die "Health check failed after ${MAX_RETRIES} attempts (last status: HTTP ${STATUS})."
+  fi
+
+  log "Attempt ${i}/${MAX_RETRIES}: HTTP ${STATUS} — retrying in ${RETRY_DELAY}s..."
+  sleep "${RETRY_DELAY}"
+done
+
+log "Deployment to ${ENVIRONMENT} complete."


### PR DESCRIPTION
Here's a PR description you can use:

Title: ci: add full CI/CD pipeline

Summary
Restructured the existing ci.yaml to run lint, typecheck, and unit tests in parallel, with Docker builds gated behind all three passing. Added npm and Docker layer caching throughout.
Fixed MegaLinter config — was using ENABLE_LINTERS (expects specific linter IDs) instead of ENABLE (language names), and was missing GITHUB_TOKEN needed to post PR comments.
Added 13 new GitHub Actions workflows covering the full CI/CD lifecycle: commit enforcement, secret scanning, dependency auditing, integration tests, E2E tests (Playwright), Lighthouse performance budgets, OWASP ZAP + Snyk security scans, automated releases via Changesets, staging/production deploy with manual approval gate, and GitHub Pages deployment for docs + OpenAPI spec.
Added supporting config: renovate.json for automated dependency updates, commitlint.config.js for conventional commit enforcement, .lighthouserc.json for performance budgets.
Added repo scaffolding: CODEOWNERS, issue templates (bug + feature), updated CONTRIBUTING.md with changeset workflow and commit conventions, .env.example documenting all required environment variables.
Added utility scripts: scripts/deploy.sh, backend/scripts/validate-env.ts, backend/scripts/generate-openapi.ts.
Test plan
 Verify MegaLinter posts comments on a test PR
 Open a PR with a non-conventional commit message and confirm commitlint fails
 Open a PR without a changeset and confirm changeset-check fails (then try with chore: prefix to confirm skip)
 Confirm audit and secret-scan jobs run on PRs
 Merge to main and verify release, deploy, docs, and openapi workflows trigger
 Confirm stale workflow runs on its daily cron