### PR TITLE
fix: anthrophic key not required

### DIFF
--- a/backend/scripts/trace_schemas_script.py
+++ b/backend/scripts/trace_schemas_script.py
@@ -45,10 +45,9 @@ from collections import defaultdict
 from rapidfuzz import fuzz
  
 s3 = boto3.client("s3")
-claude = anthropic.Anthropic()  # picks up ANTHROPIC_API_KEY from env
 BUCKET = "forge-s26-trace-evaluations"
 courses = defaultdict(dict)
-scrape_claude = True
+scrape_claude = False
 
 def extract_tables(pdf_bytes):
     results = []
@@ -69,6 +68,7 @@ def extract_tables(pdf_bytes):
 def extract_charts_with_claude(pdf_bytes):
     import pypdf
 
+    claude = anthropic.Anthropic()
     reader = pypdf.PdfReader(io.BytesIO(pdf_bytes))
     writer = pypdf.PdfWriter()
     for page in reader.pages[-1:]:  # last two pages only


### PR DESCRIPTION
This pull request makes a minor change to the `trace_schemas_script.py` script, primarily affecting how the Claude API client is instantiated and when it is used.

- The global instantiation of the `claude` client was removed and is now done locally within the `extract_charts_with_claude` function, ensuring the client is only created when needed. [[1]](diffhunk://#diff-72d1f1604022ed43ea7054adf165ed51a403bb32ad82c2be6dc874e7d61ce6f7L48-R50) [[2]](diffhunk://#diff-72d1f1604022ed43ea7054adf165ed51a403bb32ad82c2be6dc874e7d61ce6f7R71)
- The `scrape_claude` flag is now set to `False` by default, disabling Claude scraping unless explicitly enabled.