### PR TITLE
fix: use webpack instead of Turbopack for dev server

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
## Summary
- Updates `frontend/package.json` dev script to use `next dev --webpack` instead of the default Turbopack
- Turbopack (Next.js 16 default) fails to resolve Tailwind CSS v4's `@import "tailwindcss"` in `globals.css`, throwing `Can't resolve 'tailwindcss'`
- Webpack handles the `@tailwindcss/postcss` PostCSS plugin correctly and resolves the import

## Test plan
- [ ] Run `npm run dev` from the `frontend/` directory — dev server should start without errors
- [ ] Verify the app loads with correct styles applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)